### PR TITLE
Change name to signature property in DataTransferObjectMakeCommand

### DIFF
--- a/src/Console/Commands/DataTransferObjectMakeCommand.php
+++ b/src/Console/Commands/DataTransferObjectMakeCommand.php
@@ -12,7 +12,7 @@ final class DataTransferObjectMakeCommand extends GeneratorCommand
     /**
      * @var string
      */
-    protected $name = "make:dto {name : The DTO Name}";
+    protected $signature = "make:dto {name : The DTO Name}";
 
     /**
      * @var string


### PR DESCRIPTION
Switch from name to signature property in DataTransferObjectMakeCommand file so the artisan command works properly.